### PR TITLE
feat: add validation after parser installation

### DIFF
--- a/lua/treesitter-modules/core/manager.lua
+++ b/lua/treesitter-modules/core/manager.lua
@@ -47,9 +47,11 @@ function M.init()
                 return
             end
             if M.config.auto_install and not M.installed:has(language) then
-                ts.install(language):await(function()
-                    M.installed:add(language)
-                    M.attach(buf, language)
+                ts.install(language):await(function(err)
+                    if not err then
+                        M.installed:add(language)
+                        M.attach(buf, language)
+                    end
                 end)
             end
         end,


### PR DESCRIPTION
Improve manager logic by adding a validation in case the parser installation fails. Only adding the language to the list of installed parsers and attach to the buffer in case the installation was successful, otherwise skip that logic.